### PR TITLE
feat: mac support

### DIFF
--- a/requirements/linux.txt
+++ b/requirements/linux.txt
@@ -1,0 +1,1 @@
+ovos-microphone-plugin-alsa

--- a/requirements/mac.txt
+++ b/requirements/mac.txt
@@ -1,0 +1,1 @@
+ovos-microphone-plugin-sounddevice

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,6 @@
 hivemind_bus_client>=0.0.4a10
 ovos-audio
 ovos-dinkum-listener>=0.0.3
-ovos-microphone-plugin-alsa
 ovos-vad-plugin-silero
 ovos-stt-plugin-server
 ovos-tts-plugin-server

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,11 @@ setup(
     name='HiveMind-voice-sat',
     version=get_version(),
     packages=['hivemind_voice_satellite'],
-    install_requires=required("requirements.txt"),
+    install_requires=required("requirements/requirements.txt"),
+    extras_require={
+        'mac': required('requirements/mac.txt'),
+        'linux': required('requirements/linux.txt'),
+    },
     include_package_data=True,
     url='https://github.com/OpenJarbas/HiveMind-voice-sat',
     license='MIT',


### PR DESCRIPTION
However, won't entirely work unless there's an update to hivemind_bus_client:

```sh
❯ hivemind-voice-sat --host wss://hivemind.graywind.org --port 443 --key  "KEY" --password "PASSWORD" --selfsigned
2025-07-21 20:42:52,321 - WARNING - Z85P C library not available: Unsupported architecture: arm64. Falling back to pure Python implementation.
2025-07-21 20:42:52,322 - WARNING - Base91 C library not available: Unsupported architecture: arm64. Falling back to pure Python implementation.
2025-07-21 20:42:52,322 - WARNING - Z85B C library not available: Unsupported architecture: arm64. Falling back to pure Python implementation.
2025-07-21 20:42:52.877 - OVOS - ovos_utils.messagebus:<module>:5 - WARNING - Deprecation version=1.0.0. Caller=hivemind_ggwave:13. ovos_utils.messagebus has been deprecated since version 0.1.0!! please import from ovos_utils.fakebus or ovos_bus_client directly
2025-07-21 20:42:52.884 - HiveMind-voice-sat - hivemind_bus_client.client:__init__:136 - INFO - Session ID: c6c3f651-0051-4c1b-b5ff-0a6e92c394ad
2025-07-21 20:42:52.885 - HiveMind-voice-sat - ovos_bus_client.conf:load_message_bus_config:28 - DEBUG - Loading message bus configs
2025-07-21 20:42:52.885 - HiveMind-voice-sat - hivemind_bus_client.client:on_mycroft:403 - DEBUG - registering mycroft event: ovos.session.update_default
2025-07-21 20:42:52.886 - HiveMind-voice-sat - hivemind_bus_client.client:connect:199 - DEBUG - Initializing HiveMindSlaveProtocol
2025-07-21 20:42:52.887 - HiveMind-voice-sat - hivemind_bus_client.client:connect:210 - INFO - Connecting to Hivemind
2025-07-21 20:42:53.022 - HiveMind-voice-sat - hivemind_bus_client.client:on_open:220 - DEBUG - Connected
2025-07-21 20:42:54.920 - HiveMind-voice-sat - hivemind_bus_client.protocol:bind:104 - INFO - Initializing HiveMindSlaveInternalProtocol
2025-07-21 20:42:54.921 - HiveMind-voice-sat - hivemind_bus_client.protocol:bind:107 - INFO - registering protocol handlers
2025-07-21 20:42:54.922 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.HELLO
2025-07-21 20:42:54.922 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.BROADCAST
2025-07-21 20:42:54.923 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.PROPAGATE
2025-07-21 20:42:54.924 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.INTERCOM
2025-07-21 20:42:54.925 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.ESCALATE
2025-07-21 20:42:54.925 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.SHARED_BUS
2025-07-21 20:42:54.926 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.BUS
2025-07-21 20:42:54.926 - HiveMind-voice-sat - hivemind_bus_client.client:on:417 - DEBUG - registering handler: HiveMessageType.HANDSHAKE
2025-07-21 20:42:59.934 - HiveMind-voice-sat - hivemind_bus_client.protocol:start_handshake:144 - INFO - hivemind does not support binarization protocol
Traceback (most recent call last):
  File "/Users/mike/.venvs/hivemind/bin/hivemind-voice-sat", line 8, in <module>
    sys.exit(connect())
             ^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/hivemind_voice_satellite/__main__.py", line 78, in connect
    bus.connect(site_id=siteid)
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/hivemind_bus_client/client.py", line 213, in connect
    self.wait_for_handshake()
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/hivemind_bus_client/client.py", line 239, in wait_for_handshake
    self.protocol.start_handshake()
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/hivemind_bus_client/protocol.py", line 148, in start_handshake
    "ciphers": optimal_ciphers()}
               ^^^^^^^^^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/hivemind_bus_client/encryption.py", line 121, in optimal_ciphers
    if not cpu_supports_AES():
           ^^^^^^^^^^^^^^^^^^
  File "/Users/mike/.venvs/hivemind/lib/python3.11/site-packages/hivemind_bus_client/encryption.py", line 35, in cpu_supports_AES
    return "aes" in get_cpu_info()["flags"]
                    ~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'flags'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation process to support platform-specific optional dependencies for macOS and Linux.
  * Added new microphone plugin dependencies for Linux and macOS environments.
  * Adjusted main requirements path and removed redundant dependencies from the general requirements list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->