### PR TITLE
docs: correct claims that no longer match the code

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Options:
 ## Identity file
 
 When `--host`, `--key`, and `--password` are all omitted, the satellite reads
-`~/.config/mycroft/identity2.json` (the standard OVOS `NodeIdentity` file).
+`~/.config/hivemind/_identity.json` (the HiveMind `NodeIdentity` file).
 Populate it with:
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,7 @@ hivemind-client set-identity \
   --key abc123... \
   --password def456...
 
-hivemind-voice-sat   # reads ~/.config/mycroft/identity2.json
+hivemind-voice-sat   # reads ~/.config/hivemind/_identity.json
 ```
 
 If neither credentials nor an identity file are present, the satellite falls back to GGWave. It listens for an audio-encoded identity broadcast from the hive (see `hivemind-ggwave`).


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Part of an ecosystem-wide documentation accuracy pass. Five audit passes cross-checked every documented claim against freshly-synced `dev` source; this branch carries the corrections for this repo. Each fix cites the source that disproves the old wording.

Two findings turned out to be **code** bugs rather than doc bugs, and are reported separately rather than papered over here:
- the MicroPython client answers PING with a `pong` frame using wire code 13, which is unassigned in the reference `_INT2TYPE`, so a reference decoder rejects it;
- `emit_intercom` sends a hybrid envelope (`encrypted_key`/`ciphertext`/`tag`/`nonce`) while hivemind-core RSA-decrypts the `ciphertext` field directly, so an INTERCOM addressed to the hub itself cannot be decrypted. Peer-to-peer INTERCOM relayed through the hub is unaffected.